### PR TITLE
Fix issue with missing definition of var in regr test

### DIFF
--- a/test/RegressionTests/PMFRG.getXBubble.common.jl
+++ b/test/RegressionTests/PMFRG.getXBubble.common.jl
@@ -9,6 +9,8 @@ function compare_arguments_post(Xexp, X)
             abs_diff = abs.(val .- expval)
             total_diff = sum(abs_diff)
             if total_diff > 1e-14
+                different_val_places = val .!= expval
+
                 print("Test failed: $field differs significantly: ")
                 print("Absolute Difference: ", total_diff, ", ")
                 print("Maximum Difference: ", maximum(abs_diff), ", ")

--- a/test/UnitTests/TypeStability.jl
+++ b/test/UnitTests/TypeStability.jl
@@ -67,8 +67,11 @@ function test_TwoLoopAllocations(Par = Params(getPolymer(2), TwoLoop()))
     XB = take!(WS.Buffer.X)
 
     PropB = convertToSMatrix(PropB_0)
+    PropBMatrix = Matrix(PropB)
 
     test_TwoLoopAllocations(Par, WS, PropB, VB, XB)
+    test_TwoLoopAllocations(Par, WS, PropBMatrix, VB, XB)
+
     put!(WS.Buffer.Vertex, VB)
     put!(WS.Buffer.X, XB)
     put!(WS.Buffer.Props, PropB_0)

--- a/test/UnitTests/TypeStability.jl
+++ b/test/UnitTests/TypeStability.jl
@@ -18,7 +18,11 @@ function test_OneLoopAllocations(Par = Params(getPolymer(2)))
     SBuff = take!(WS.Buffer.Props)
     VBuff = take!(WS.Buffer.Vertex)
     SBuff1 = convertToSMatrix(SBuff)
+
+    SBuffMatrix = Matrix(SBuff1)
     test_OneLoopAllocations(Par, WS, SBuff1, VBuff)
+    test_OneLoopAllocations(Par, WS, SBuffMatrix, VBuff)
+
     put!(WS.Buffer.Props, SBuff)
     put!(WS.Buffer.Vertex, VBuff)
 end


### PR DESCRIPTION
In [a function used in regression tests](https://github.com/NilsNiggemann/PMFRG.jl/compare/master...mmesiti:PMFRG.jl:undeclared-different-val-places-fix?expand=1#diff-b04eb256a32c36c6224d663c164f4098a58d84b26d4260abe45207be9544d023) the definition of a variable was missing, causing tests to fail (apparently only with Julia 1.10, because the tests with Julia 1.9.4 passed). 


